### PR TITLE
allow for multiple versions when scanning for packages

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -27,7 +27,7 @@ def do_scan():
             path = '/data/dists/{}/main/binary-{}'.format(dist, arch)
             if not os.path.exists(path):
                 os.makedirs(path)
-            cmd = 'dpkg-scanpackages . | gzip -9c > {0}/Packages.gz'.format(path)
+            cmd = 'dpkg-scanpackages -m . | gzip -9c > {0}/Packages.gz'.format(path)
             sp.check_call(cmd, shell=True, close_fds=True)
     info('Scanning...done')
 


### PR DESCRIPTION
By default `dpkg-scanpackages` ignores multiple versions of packages, by adding the `-m` flag they are added to the output, which then in turn enables the users of the repository to install older versions if necessary.